### PR TITLE
[MODLOGINKC-1] token endpoint response adjustments

### DIFF
--- a/src/main/java/org/folio/login/controller/LoginController.java
+++ b/src/main/java/org/folio/login/controller/LoginController.java
@@ -62,10 +62,11 @@ public class LoginController implements LoginApi {
   }
 
   @Override
-  public ResponseEntity<LoginResponse> token(String code, String redirectUri, String userAgent, String forwardedFor) {
+  public ResponseEntity<LoginResponseWithExpiry> token(String code, String redirectUri, String userAgent,
+    String forwardedFor) {
     var tokenContainer = loginService.token(code, redirectUri, userAgent, forwardedFor);
     var cookieHeaders = tokenCookieHeaderManager.createAuthorizationCookieHeader(tokenContainer);
-    var loginResponse = buildLoginResponse(tokenContainer);
+    var loginResponse = buildLoginWithExpiryResponse(tokenContainer);
     return ResponseEntity.status(CREATED)
       .headers(cookieHeaders)
       .headers(createTokenHeaderIfNeeds(tokenContainer.getAccessToken().getJwt()))

--- a/src/main/resources/swagger.api/mod-login-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-login-keycloak.yaml
@@ -178,7 +178,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/loginResponse'
+                $ref: '#/components/schemas/loginResponseWithExpiry'
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '422':

--- a/src/main/resources/swagger.api/schemas/error.json
+++ b/src/main/resources/swagger.api/schemas/error.json
@@ -14,9 +14,11 @@
       "description": "Error message type"
     },
     "code": {
+      "description": "Error message code",
       "$ref": "errorCode.json"
     },
     "parameters": {
+      "description": "List of key/value parameters of an error",
       "$ref": "parameters.json"
     }
   }

--- a/src/main/resources/swagger.api/schemas/logEvent.json
+++ b/src/main/resources/swagger.api/schemas/logEvent.json
@@ -10,6 +10,7 @@
       "description": "The system assigned unique ID of the instance record; UUID"
     },
     "eventType": {
+      "description": "Log event type",
       "$ref": "logEventType.json"
     },
     "tenant": {

--- a/src/test/java/org/folio/login/controller/LoginControllerTest.java
+++ b/src/test/java/org/folio/login/controller/LoginControllerTest.java
@@ -117,7 +117,7 @@ class LoginControllerTest {
   @Test
   void token_positive() throws Exception {
     var tokenContainer = tokenContainer();
-    var loginResponse = loginResponse();
+    var loginResponse = loginResponseWithExpiry();
     var code = "secret_code";
     var redirect = "localhost";
 
@@ -139,7 +139,7 @@ class LoginControllerTest {
   @Test
   void token_positive_withoutTokenHeader() throws Exception {
     var tokenContainer = tokenContainer();
-    var loginResponse = loginResponse();
+    var loginResponse = loginResponseWithExpiry();
 
     var code = "secret_code";
     var redirect = "localhost";

--- a/src/test/java/org/folio/login/it/CacheConfigIT.java
+++ b/src/test/java/org/folio/login/it/CacheConfigIT.java
@@ -1,11 +1,11 @@
 package org.folio.login.it;
 
 import static java.time.Duration.ofMillis;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.login.support.TestConstants.KEYCLOAK_CONFIG_CACHE;
 import static org.folio.login.support.TestConstants.TOKEN_CACHE;
+import static org.folio.login.support.TestUtils.cleanUpCaches;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -89,9 +89,5 @@ class CacheConfigIT extends BaseIntegrationTest {
       assertNull(cache.get("key1"));
       assertNull(cache.get("key2"));
     });
-  }
-
-  public static void cleanUpCaches(CacheManager cacheManager) {
-    cacheManager.getCacheNames().forEach(name -> requireNonNull(cacheManager.getCache(name)).clear());
   }
 }

--- a/src/test/java/org/folio/login/support/TestUtils.java
+++ b/src/test/java/org/folio/login/support/TestUtils.java
@@ -1,0 +1,14 @@
+package org.folio.login.support;
+
+import static java.util.Objects.requireNonNull;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.cache.CacheManager;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TestUtils {
+  public static void cleanUpCaches(CacheManager cacheManager) {
+    cacheManager.getCacheNames().forEach(name -> requireNonNull(cacheManager.getCache(name)).clear());
+  }
+}

--- a/src/test/java/org/folio/login/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/login/support/base/BaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.folio.login.support.base;
 
+import static org.folio.login.support.TestUtils.cleanUpCaches;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -12,8 +13,11 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.test.base.BaseBackendIntegrationTest;
 import org.folio.test.extensions.EnableKeycloak;
 import org.folio.test.extensions.EnablePostgres;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -25,6 +29,14 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @ActiveProfiles("it")
 @AutoConfigureMockMvc
 public abstract class BaseIntegrationTest extends BaseBackendIntegrationTest {
+
+  @Autowired
+  private CacheManager cacheManager;
+
+  @BeforeEach
+  void setUp() {
+    cleanUpCaches(cacheManager);
+  }
 
   public static ResultActions attemptGet(String uri, Object... args) throws Exception {
     return mockMvc.perform(get(uri, args).contentType(APPLICATION_JSON));


### PR DESCRIPTION
## Purpose
return access/refresh tokens in http-only cookies it's described that the ""token"" endpoint in mod-login-keycloak will support two modes, one which returns AT/RT in cookies as well as response headers, and another which only returns the cookies. The response body in both modes should conform to https://github.com/folio-org/mod-login/blob/master/ramls/loginResponseWithExpiry.json (AT expiration and RT expiration)

JIRA: https://issues.folio.org/browse/MODLOGINKC-1

## Approach
- Adjust schema and code
- Update tests
- Add caches cleanup after test executions

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
