### PR TITLE
Change Jenkins build node to "bigmem"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildMvn {
   publishModDescriptor = false
   mvnDeploy = true
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java17-bigmem'
 }


### PR DESCRIPTION
## Purpose
Fix build issues with insufficient resources by changing Jenkins build node to "bigmem"