### PR TITLE
MODLOGINKC-10: change refresh token cookie path

### DIFF
--- a/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
+++ b/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
@@ -18,6 +18,9 @@ public class TokenCookieHeaderManager {
   public static final String FOLIO_ACCESS_TOKEN = "folioAccessToken";
   public static final String FOLIO_REFRESH_TOKEN = "folioRefreshToken";
 
+  private static final String ACCESS_TOKEN_PATH = "/";
+  private static final String FOLIO_REFRESH_PATH = "/authn";
+
   private final CookieProperties cookieProperties;
 
   public HttpHeaders createAuthorizationCookieHeader(TokenContainer tokenContainer) {
@@ -25,16 +28,18 @@ public class TokenCookieHeaderManager {
     var refreshToken = tokenContainer.getRefreshToken();
 
     var headers = new HttpHeaders();
-    headers.add(SET_COOKIE, createHeader(FOLIO_ACCESS_TOKEN, accessToken.getJwt(), accessToken.getExpiresIn()));
-    headers.add(SET_COOKIE, createHeader(FOLIO_REFRESH_TOKEN, refreshToken.getJwt(), refreshToken.getExpiresIn()));
+    headers.add(SET_COOKIE, createHeader(FOLIO_ACCESS_TOKEN, accessToken.getJwt(), accessToken.getExpiresIn(), 
+      ACCESS_TOKEN_PATH));
+    headers.add(SET_COOKIE, createHeader(FOLIO_REFRESH_TOKEN, refreshToken.getJwt(), refreshToken.getExpiresIn(), 
+      FOLIO_REFRESH_PATH));
     return headers;
   }
 
-  private String createHeader(String name, String value, Long maxAge) {
+  private String createHeader(String name, String value, Long maxAge, String path) {
     return ResponseCookie.from(name, value)
       .httpOnly(true)
       .secure(true)
-      .path("/")
+      .path(path)
       .maxAge(maxAge)
       .sameSite(cookieProperties.getSameSiteValue())
       .build()

--- a/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
+++ b/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
@@ -19,7 +19,7 @@ public class TokenCookieHeaderManager {
   public static final String FOLIO_REFRESH_TOKEN = "folioRefreshToken";
 
   private static final String ACCESS_TOKEN_PATH = "/";
-  private static final String FOLIO_REFRESH_PATH = "/authn";
+  private static final String FOLIO_REFRESH_PATH = "/authn"; //NOSONAR
 
   private final CookieProperties cookieProperties;
 
@@ -28,9 +28,9 @@ public class TokenCookieHeaderManager {
     var refreshToken = tokenContainer.getRefreshToken();
 
     var headers = new HttpHeaders();
-    headers.add(SET_COOKIE, createHeader(FOLIO_ACCESS_TOKEN, accessToken.getJwt(), accessToken.getExpiresIn(), 
+    headers.add(SET_COOKIE, createHeader(FOLIO_ACCESS_TOKEN, accessToken.getJwt(), accessToken.getExpiresIn(),
       ACCESS_TOKEN_PATH));
-    headers.add(SET_COOKIE, createHeader(FOLIO_REFRESH_TOKEN, refreshToken.getJwt(), refreshToken.getExpiresIn(), 
+    headers.add(SET_COOKIE, createHeader(FOLIO_REFRESH_TOKEN, refreshToken.getJwt(), refreshToken.getExpiresIn(),
       FOLIO_REFRESH_PATH));
     return headers;
   }

--- a/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
+++ b/src/main/java/org/folio/login/service/TokenCookieHeaderManager.java
@@ -18,9 +18,6 @@ public class TokenCookieHeaderManager {
   public static final String FOLIO_ACCESS_TOKEN = "folioAccessToken";
   public static final String FOLIO_REFRESH_TOKEN = "folioRefreshToken";
 
-  private static final String ACCESS_TOKEN_PATH = "/";
-  private static final String FOLIO_REFRESH_PATH = "/authn"; //NOSONAR
-
   private final CookieProperties cookieProperties;
 
   public HttpHeaders createAuthorizationCookieHeader(TokenContainer tokenContainer) {
@@ -29,9 +26,9 @@ public class TokenCookieHeaderManager {
 
     var headers = new HttpHeaders();
     headers.add(SET_COOKIE, createHeader(FOLIO_ACCESS_TOKEN, accessToken.getJwt(), accessToken.getExpiresIn(),
-      ACCESS_TOKEN_PATH));
+      "/"));
     headers.add(SET_COOKIE, createHeader(FOLIO_REFRESH_TOKEN, refreshToken.getJwt(), refreshToken.getExpiresIn(),
-      FOLIO_REFRESH_PATH));
+      "/authn"));
     return headers;
   }
 

--- a/src/test/java/org/folio/login/service/TokenCookieManagerTest.java
+++ b/src/test/java/org/folio/login/service/TokenCookieManagerTest.java
@@ -38,7 +38,7 @@ class TokenCookieManagerTest {
         String.format("Max-Age=%s;", EXPIRES_IN),
         "Secure;", "HttpOnly;", String.format("SameSite=%s", properties.getSameSiteValue()));
     assertThat(result.get(SET_COOKIE).get(1).split(" "))
-      .contains(String.format("folioRefreshToken=%s;", REFRESH_TOKEN), "Path=/;",
+      .contains(String.format("folioRefreshToken=%s;", REFRESH_TOKEN), "Path=/authn;",
         String.format("Max-Age=%s;", REFRESH_EXPIRES_IN),
         "Secure;", "HttpOnly;", String.format("SameSite=%s", properties.getSameSiteValue()));
   }


### PR DESCRIPTION
## Purpose

[MODLOGINKC-10](https://folio-org.atlassian.net/browse/MODLOGINKC-10)
Refresh token path in cookies should be changed `/` -> `/authn`

## Approach

- adjust logic
- adjust tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
