### PR TITLE
MODLOGINKC-15 Provide an expired cookie header upon logout

### DIFF
--- a/src/main/java/org/folio/login/controller/LoginController.java
+++ b/src/main/java/org/folio/login/controller/LoginController.java
@@ -52,13 +52,17 @@ public class LoginController implements LoginApi {
   @Override
   public ResponseEntity<Void> logout(String folioRefreshTokenRequired) {
     loginService.logout(folioRefreshTokenRequired);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.noContent()
+      .headers(tokenCookieHeaderManager.createAuthorizationCookieHeader(TokenContainer.empty()))
+      .build();
   }
 
   @Override
   public ResponseEntity<Void> logoutAll() {
     loginService.logoutAll();
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.noContent()
+      .headers(tokenCookieHeaderManager.createAuthorizationCookieHeader(TokenContainer.empty()))
+      .build();
   }
 
   @Override

--- a/src/main/java/org/folio/login/domain/model/TokenContainer.java
+++ b/src/main/java/org/folio/login/domain/model/TokenContainer.java
@@ -23,4 +23,13 @@ public class TokenContainer {
     }
     return refreshToken.getExpirationDate();
   }
+
+  /**
+   * Creates a {@link TokenContainer} with null access and refresh tokens.
+   *
+   * @return empty {@link TokenContainer} object
+   */
+  public static TokenContainer empty() {
+    return new TokenContainer(null, null);
+  }
 }

--- a/src/test/java/org/folio/login/it/LoginIT.java
+++ b/src/test/java/org/folio/login/it/LoginIT.java
@@ -113,7 +113,9 @@ class LoginIT extends BaseIntegrationTest {
         .header(XOkapiHeaders.USER_ID, USER_ID)
         .header(XOkapiHeaders.URL, OKAPI_URL)
         .header(XOkapiHeaders.TENANT, TENANT))
-      .andExpect(status().isNoContent());
+      .andExpect(status().isNoContent())
+      .andExpect(cookie().httpOnly(FOLIO_ACCESS_TOKEN, true))
+      .andExpect(cookie().httpOnly(FOLIO_REFRESH_TOKEN, true));
 
     assertThat(loadKcUserSessions()).isEmpty();
     verify(keycloakService).logoutAll();
@@ -131,7 +133,9 @@ class LoginIT extends BaseIntegrationTest {
         .header(XOkapiHeaders.USER_ID, USER_ID)
         .header(XOkapiHeaders.URL, OKAPI_URL)
         .header(XOkapiHeaders.TENANT, TENANT))
-      .andExpect(status().isNoContent());
+      .andExpect(status().isNoContent())
+      .andExpect(cookie().httpOnly(FOLIO_ACCESS_TOKEN, true))
+      .andExpect(cookie().httpOnly(FOLIO_REFRESH_TOKEN, true));
 
     assertThat(loadKcUserSessions()).isEmpty();
   }
@@ -171,7 +175,9 @@ class LoginIT extends BaseIntegrationTest {
         .header(XOkapiHeaders.TENANT, TENANT)
         .cookie(new Cookie(FOLIO_ACCESS_TOKEN, tokens.getOkapiToken()),
           new Cookie(FOLIO_REFRESH_TOKEN, tokens.getRefreshToken())))
-      .andExpect(status().isNoContent());
+      .andExpect(status().isNoContent())
+      .andExpect(cookie().httpOnly(FOLIO_ACCESS_TOKEN, true))
+      .andExpect(cookie().httpOnly(FOLIO_REFRESH_TOKEN, true));
   }
 
   private static ResultActions doPost(String endpoint, Object payload) throws Exception {


### PR DESCRIPTION
## Purpose

Removes refresh and access token cookies upon logout

## Approach

- Provide expired access and refresh token empty cookies upon logout and logoutAll operations
- Adjust unit and integration tests 

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
