### PR TITLE
EUREKA-255: support cross tenant token refreshing

### DIFF
--- a/src/main/java/org/folio/login/service/KeycloakService.java
+++ b/src/main/java/org/folio/login/service/KeycloakService.java
@@ -79,6 +79,13 @@ public class KeycloakService {
     keycloakClient.logoutAll(tenantId, keycloakUserId, token);
   }
 
+  /**
+   * Refreshes the access token using the refresh token. The original realm is extracted from the refresh token. The
+   * `x-okapi-tenant` header is overridden with the tenant from the refresh token.
+   *
+   * @param refreshToken the refresh token
+   * @return the refreshed access token
+   */
   public KeycloakAuthentication refreshToken(String refreshToken) {
     var headers = new HashMap<>(folioExecutionContext.getAllHeaders());
     headers.put(OkapiHeaders.TENANT, List.of(extractTenant(refreshToken)));

--- a/src/main/java/org/folio/login/util/JwtUtils.java
+++ b/src/main/java/org/folio/login/util/JwtUtils.java
@@ -5,7 +5,6 @@ import static org.keycloak.util.TokenUtil.getRefreshToken;
 
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.StringUtils;
 
 @UtilityClass
 public class JwtUtils {

--- a/src/main/java/org/folio/login/util/JwtUtils.java
+++ b/src/main/java/org/folio/login/util/JwtUtils.java
@@ -1,0 +1,17 @@
+package org.folio.login.util;
+
+import static org.keycloak.util.TokenUtil.getRefreshToken;
+
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+
+@UtilityClass
+public class JwtUtils {
+
+  @SneakyThrows
+  public static String extractTenant(String refreshToken) {
+    var token = getRefreshToken(refreshToken);
+    return StringUtils.substringAfterLast(token.getIssuer(), "/");
+  }
+}

--- a/src/main/java/org/folio/login/util/JwtUtils.java
+++ b/src/main/java/org/folio/login/util/JwtUtils.java
@@ -1,5 +1,6 @@
 package org.folio.login.util;
 
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import static org.keycloak.util.TokenUtil.getRefreshToken;
 
 import lombok.SneakyThrows;
@@ -12,6 +13,6 @@ public class JwtUtils {
   @SneakyThrows
   public static String extractTenant(String refreshToken) {
     var token = getRefreshToken(refreshToken);
-    return StringUtils.substringAfterLast(token.getIssuer(), "/");
+    return substringAfterLast(token.getIssuer(), "/");
   }
 }

--- a/src/test/java/org/folio/login/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/login/service/KeycloakServiceTest.java
@@ -28,6 +28,7 @@ import static org.folio.login.support.TestValues.refreshTokenRequest;
 import static org.folio.login.support.TestValues.updateCredentials;
 import static org.folio.login.support.TestValues.updatePassword;
 import static org.folio.login.support.TestValues.userCredentials;
+import static org.folio.test.security.TestJwtGenerator.generateJwtToken;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -329,7 +330,8 @@ class KeycloakServiceTest {
 
   @Test
   void refreshToken_positive() {
-    var requestData = refreshTokenRequest(REFRESH_TOKEN);
+    var refreshToken = generateJwtToken("http://localhost:8081", TENANT);
+    var requestData = refreshTokenRequest(refreshToken);
     var realmConfiguration = keycloakRealmConfiguration();
     var keycloakAuth = keycloakAuthentication();
 
@@ -338,7 +340,7 @@ class KeycloakServiceTest {
     when(keycloakClient.callTokenEndpoint(any(), any(), any(), any()))
       .thenReturn(keycloakAuth);
 
-    var actualAuth = keycloakService.refreshToken(REFRESH_TOKEN);
+    var actualAuth = keycloakService.refreshToken(refreshToken);
     assertThat(actualAuth).isEqualTo(keycloakAuth);
 
     var captor = ArgumentCaptor.forClass(Map.class);

--- a/src/test/java/org/folio/login/util/JwtUtilsTest.java
+++ b/src/test/java/org/folio/login/util/JwtUtilsTest.java
@@ -1,0 +1,21 @@
+package org.folio.login.util;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.folio.test.security.TestJwtGenerator;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class JwtUtilsTest {
+
+  @Test
+  void extractTenant_positive() {
+    var tenantId = "testtenant";
+    var testToken = TestJwtGenerator.generateJwtToken("http://localhost:8081", tenantId);
+
+    var extractedTenant = JwtUtils.extractTenant(testToken);
+
+    assertThat(extractedTenant).isEqualTo(tenantId);
+  }
+}


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/EUREKA-255
There is an error while the token is refreshing if the original keycloak realm is different from `x-okapi-tenant` header.

## Approach

- ignore `x-okapi-tenant` and extract the realm token that belongs to
- add tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

