### PR TITLE
Bump up applications-poc-tools dependencies to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <folio-spring-support.version>8.1.2</folio-spring-support.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
-    <applications-poc-tools.version>1.5.5</applications-poc-tools.version>
+    <applications-poc-tools.version>1.5.6</applications-poc-tools.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>
 
     <mod-login-keycloak.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-login-keycloak.yaml
@@ -53,6 +54,12 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-support.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${applications-poc-tools.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/login/integration/keycloak/config/KeycloakAdminConfiguration.java
+++ b/src/main/java/org/folio/login/integration/keycloak/config/KeycloakAdminConfiguration.java
@@ -2,10 +2,12 @@ package org.folio.login.integration.keycloak.config;
 
 import static jakarta.ws.rs.client.ClientBuilder.newBuilder;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
-import static org.apache.http.conn.ssl.NoopHostnameVerifier.INSTANCE;
-import static org.folio.common.utils.FeignClientTlsUtils.buildSslContext;
+import static org.folio.common.utils.tls.FeignClientTlsUtils.buildSslContext;
+import static org.folio.common.utils.tls.Utils.IS_HOSTNAME_VERIFICATION_DISABLED;
 
 import lombok.extern.log4j.Log4j2;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.folio.common.configuration.properties.TlsProperties;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.keycloak.OAuth2Constants;
@@ -19,6 +21,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties({KeycloakProperties.class})
 public class KeycloakAdminConfiguration {
+
+  private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
 
   @Bean
   public Keycloak keycloak(KeycloakProperties properties) {
@@ -40,6 +44,9 @@ public class KeycloakAdminConfiguration {
   }
 
   private static ResteasyClient buildResteasyClient(TlsProperties properties) {
-    return (ResteasyClient) newBuilder().sslContext(buildSslContext(properties)).hostnameVerifier(INSTANCE).build();
+    return (ResteasyClient) newBuilder()
+      .sslContext(buildSslContext(properties))
+      .hostnameVerifier(IS_HOSTNAME_VERIFICATION_DISABLED ? NoopHostnameVerifier.INSTANCE : DEFAULT_HOSTNAME_VERIFIER)
+      .build();
   }
 }

--- a/src/main/java/org/folio/login/integration/keycloak/config/KeycloakFeignConfiguration.java
+++ b/src/main/java/org/folio/login/integration/keycloak/config/KeycloakFeignConfiguration.java
@@ -5,7 +5,7 @@ import feign.codec.Encoder;
 import feign.form.FormEncoder;
 import feign.okhttp.OkHttpClient;
 import lombok.extern.log4j.Log4j2;
-import org.folio.common.utils.FeignClientTlsUtils;
+import org.folio.common.utils.tls.FeignClientTlsUtils;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.cloud.openfeign.support.SpringEncoder;

--- a/src/test/java/org/folio/login/it/DisableHostnameVerificationConfig.java
+++ b/src/test/java/org/folio/login/it/DisableHostnameVerificationConfig.java
@@ -1,0 +1,13 @@
+package org.folio.login.it;
+
+import static org.apache.commons.lang3.SystemProperties.JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DisableHostnameVerificationConfig {
+
+  static {
+    System.setProperty(JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION, "true");
+  }
+}


### PR DESCRIPTION
## Purpose
Bump up applications-poc-tools dependencies to 1.5.6 to support Hostname Verification for TLS connections
