### PR TITLE
MODLOGINKC-17: JIT AuthUser creation in POST /authn/credentials

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -85,7 +85,8 @@
         {
           "methods" : [ "POST" ],
           "pathPattern" : "/authn/credentials",
-          "permissionsRequired" : [ "login.item.post" ]
+          "permissionsRequired" : [ "login.item.post" ],
+          "modulePermissions": [ "users-keycloak.auth-users.item.post" ]
         },
         {
           "methods" : [ "DELETE" ],
@@ -188,6 +189,10 @@
     {
       "id" : "users",
       "version" : "16.1"
+    },
+    {
+      "id" : "users-keycloak",
+      "version" : "1.0"
     }
   ],
   "optional" : [

--- a/src/main/java/org/folio/login/integration/users/ModUsersKeycloakClient.java
+++ b/src/main/java/org/folio/login/integration/users/ModUsersKeycloakClient.java
@@ -1,0 +1,17 @@
+package org.folio.login.integration.users;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "users-keycloak")
+public interface ModUsersKeycloakClient {
+
+  /**
+   * Create keycloak user if not exists.
+   *
+   * @param userId folio user ID, UUID.
+   */
+  @PostMapping("/auth-users/{userId}")
+  void createAuthUserInfo(@PathVariable("userId") String userId);
+}

--- a/src/main/java/org/folio/login/integration/users/UsersKeycloakClient.java
+++ b/src/main/java/org/folio/login/integration/users/UsersKeycloakClient.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(name = "users-keycloak")
-public interface ModUsersKeycloakClient {
+public interface UsersKeycloakClient {
 
   /**
    * Create keycloak user if not exists.

--- a/src/main/java/org/folio/login/service/CredentialsService.java
+++ b/src/main/java/org/folio/login/service/CredentialsService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.folio.login.domain.dto.CredentialsExistence;
 import org.folio.login.domain.dto.LoginCredentials;
 import org.folio.login.domain.dto.UpdateCredentials;
-import org.folio.login.integration.users.ModUsersKeycloakClient;
+import org.folio.login.integration.users.UsersKeycloakClient;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Service;
 public class CredentialsService {
 
   private final KeycloakService keycloakService;
-  private final ModUsersKeycloakClient modUsersKeycloakClient;
+  private final UsersKeycloakClient usersKeycloakClient;
 
   public void createAuthCredentials(LoginCredentials loginCredentials) {
-    modUsersKeycloakClient.createAuthUserInfo(loginCredentials.getUserId());
+    usersKeycloakClient.createAuthUserInfo(loginCredentials.getUserId());
     keycloakService.createAuthCredentials(loginCredentials);
   }
 

--- a/src/main/java/org/folio/login/service/CredentialsService.java
+++ b/src/main/java/org/folio/login/service/CredentialsService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.folio.login.domain.dto.CredentialsExistence;
 import org.folio.login.domain.dto.LoginCredentials;
 import org.folio.login.domain.dto.UpdateCredentials;
+import org.folio.login.integration.users.ModUsersKeycloakClient;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Service;
 public class CredentialsService {
 
   private final KeycloakService keycloakService;
+  private final ModUsersKeycloakClient modUsersKeycloakClient;
 
   public void createAuthCredentials(LoginCredentials loginCredentials) {
+    modUsersKeycloakClient.createAuthUserInfo(loginCredentials.getUserId());
     keycloakService.createAuthCredentials(loginCredentials);
   }
 

--- a/src/test/java/org/folio/login/service/CredentialsServiceTest.java
+++ b/src/test/java/org/folio/login/service/CredentialsServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.folio.login.domain.dto.CredentialsExistence;
+import org.folio.login.integration.users.ModUsersKeycloakClient;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,10 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CredentialsServiceTest {
 
   @Mock private KeycloakService keycloakService;
+  @Mock private ModUsersKeycloakClient modUsersKeycloakClient;
   @InjectMocks private CredentialsService credentialsService;
 
   @Test
   void createCredentials_positive() {
+    doNothing().when(modUsersKeycloakClient).createAuthUserInfo(loginCredentials().getUserId());
     doNothing().when(keycloakService).createAuthCredentials(loginCredentials());
     credentialsService.createAuthCredentials(loginCredentials());
     verify(keycloakService).createAuthCredentials(loginCredentials());

--- a/src/test/java/org/folio/login/service/CredentialsServiceTest.java
+++ b/src/test/java/org/folio/login/service/CredentialsServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.folio.login.domain.dto.CredentialsExistence;
-import org.folio.login.integration.users.ModUsersKeycloakClient;
+import org.folio.login.integration.users.UsersKeycloakClient;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,12 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CredentialsServiceTest {
 
   @Mock private KeycloakService keycloakService;
-  @Mock private ModUsersKeycloakClient modUsersKeycloakClient;
+  @Mock private UsersKeycloakClient usersKeycloakClient;
   @InjectMocks private CredentialsService credentialsService;
 
   @Test
   void createCredentials_positive() {
-    doNothing().when(modUsersKeycloakClient).createAuthUserInfo(loginCredentials().getUserId());
+    doNothing().when(usersKeycloakClient).createAuthUserInfo(loginCredentials().getUserId());
     doNothing().when(keycloakService).createAuthCredentials(loginCredentials());
     credentialsService.createAuthCredentials(loginCredentials());
     verify(keycloakService).createAuthCredentials(loginCredentials());

--- a/src/test/resources/wiremock/stubs/moduserskc/create-kc-user.json
+++ b/src/test/resources/wiremock/stubs/moduserskc/create-kc-user.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/users-keycloak/auth-users/.*",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "test"
+      }
+    }
+  },
+  "response": {
+    "status": 204
+  }
+}


### PR DESCRIPTION
## Purpose
Adjustments to mod-login-keycloak (POST /authn/credentials) to call the new endpoint creating AuthUser records in keycloak before attempting to set credentials. [MODLOGINKC-17](https://folio-org.atlassian.net/browse/MODLOGINKC-17)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach

- Whether or not the GET /users-keycloak/auth-users/{userId}and POST /users-keycloak/auth-users/{userId} endpoints are both called or if only the latter is called, is an implementation detail.  
- POST /users-keycloak/auth-users/{userId} is idempotent, so it’s safe to call even if the AuthUser record already exists in Keycloak.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
