### PR TITLE
FSSP-1 Adopt to changes in secure store

### DIFF
--- a/src/main/java/org/folio/login/service/RealmConfigurationProvider.java
+++ b/src/main/java/org/folio/login/service/RealmConfigurationProvider.java
@@ -6,7 +6,7 @@ import org.folio.login.domain.model.KeycloakRealmConfiguration;
 import org.folio.login.integration.keycloak.config.KeycloakProperties;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.tools.store.SecureStore;
-import org.folio.tools.store.exception.NotFoundException;
+import org.folio.tools.store.exception.SecureStoreServiceException;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +36,7 @@ public class RealmConfigurationProvider {
   private String retrieveKcClientSecret(String tenantId, String clientId) {
     try {
       return secureStore.get(buildKey(folioEnvironment.getEnvironment(), tenantId, clientId));
-    } catch (NotFoundException e) {
+    } catch (SecureStoreServiceException e) {
       throw new IllegalStateException(String.format(
         "Failed to get value from secure store [tenantId: %s, clientId: %s]", tenantId, clientId), e);
     }

--- a/src/test/java/org/folio/login/service/RealmConfigurationProviderTest.java
+++ b/src/test/java/org/folio/login/service/RealmConfigurationProviderTest.java
@@ -18,7 +18,7 @@ import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
 import org.folio.tools.store.SecureStore;
-import org.folio.tools.store.exception.NotFoundException;
+import org.folio.tools.store.exception.SecureStoreServiceException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +71,7 @@ class RealmConfigurationProviderTest {
   void getRealmConfiguration_clientSecretNotFound() {
     when(keycloakProperties.getClientSuffix()).thenReturn("-app");
     when(folioEnvironment.getEnvironment()).thenReturn("test");
-    when(secureStore.get(KEY)).thenThrow(new NotFoundException("not found"));
+    when(secureStore.get(KEY)).thenThrow(new SecureStoreServiceException("not found"));
 
     assertThatThrownBy(() -> realmConfigurationProvider.getRealmConfiguration())
       .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
### **Purpose**
Update the code to reflect the changes done in application-poc-tools in this PR: https://github.com/folio-org/applications-poc-tools/pull/218
US: [FSSP-1](https://folio-org.atlassian.net/browse/FSSP-1)

### **Approach**
* Replace `NotFoundException` with the more general `SecureStoreServiceException`, as it encompasses a broader range of scenarios— not just when a secret is missing, but also when there are issues communicating with the secure store.

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
