### PR TITLE
MODLOGINKC-44: User can't log in due to invalid token error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version `v3.1.0-SNAPSHOT` (TBD)
+* User can't log in due to invalid token error (MODLOGINKC-44)
+
 ## Version `v3.0.0` (12.03.2025)
 * Update mod-login-keycloak Java 21 (MODLOGINKC-43)
 

--- a/src/main/java/org/folio/login/service/JwtTokenParser.java
+++ b/src/main/java/org/folio/login/service/JwtTokenParser.java
@@ -30,7 +30,7 @@ public class JwtTokenParser {
     }
 
     try {
-      var payload = objectMapper.readTree(new String(Base64.getDecoder().decode(split[1])));
+      var payload = objectMapper.readTree(new String(Base64.getUrlDecoder().decode(split[1])));
       return payload.get("exp").asLong();
     } catch (Exception e) {
       log.warn("Failed to parse token", e);


### PR DESCRIPTION
### **Purpose**
Illegal base64 character 2d error during the token parsing. See [MODLOGINKC-44](https://folio-org.atlassian.net/browse/MODLOGINKC-44)

### **Approach**
- use Base64.getUrlDecoder for token payload decoding

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
