### PR TITLE
MODLOGINKC-48 - revert Use SECURE_STORE_ENV, not ENV, for secure store key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 ## Version `v3.1.0-SNAPSHOT` (TBD)
 * User can't log in due to invalid token error (MODLOGINKC-44)
 * Introduce configuration for FSSP (APPPOCTOOL-59)
-* Use SECURE_STORE_ENV, not ENV, for secure store key(MODLOGINKC-48)
 
 ## Version `v3.0.0` (12.03.2025)
 * Update mod-login-keycloak Java 21 (MODLOGINKC-43)

--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ mod-login-keycloak provides following functionality:
 
 ### Secure storage environment variables
 
-| Name                | Default value | Description                                                                                                                                                    |
-|:--------------------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SECURE_STORE_ENV    | folio         | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.     |
-
 #### AWS-SSM
 
 Required when `SECRET_STORE_TYPE=AWS_SSM`

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,6 @@ application:
       trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
   secret-store:
-    environment: ${SECURE_STORE_ENV:${ENV:folio}}
     type: ${SECRET_STORE_TYPE}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}


### PR DESCRIPTION
### **Purpose**
Revert Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**
Revert  Use SECURE_STORE_ENV, not ENV, for secure store key

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
