### PR TITLE
APPPOCTOOL-85: update KafkaUtils import paths and configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## Version `v3.1.0-SNAPSHOT` (TBD)
+* Adopt APPPOCTOOL-85 Kafka producer module split by moving from `folio-integration-kafka` to `folio-kafka-producer` (APPPOCTOOL-85)
 * Fix parameter names and typos in README curl examples (MODLOGINKC-51)
 * User can't log in due to invalid token error (MODLOGINKC-44)
 * Introduce configuration for FSSP (APPPOCTOOL-59)

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.10</openapi-tools.jackson-databind-nullable.version>
     <folio-spring-support.version>10.0.0</folio-spring-support.version>
     <folio-java-checkstyle.version>1.2.0</folio-java-checkstyle.version>
-    <applications-poc-tools.version>4.0.0-SNAPSHOT</applications-poc-tools.version>
+    <applications-poc-tools.version>4.1.0-SNAPSHOT</applications-poc-tools.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <mod-login-keycloak.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-login-keycloak.yaml
     </mod-login-keycloak.yaml-file>
@@ -86,7 +86,7 @@
 
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>folio-integration-kafka</artifactId>
+      <artifactId>folio-kafka-producer</artifactId>
       <version>${applications-poc-tools.version}</version>
     </dependency>
 

--- a/src/main/java/org/folio/login/LoginKeycloakApplication.java
+++ b/src/main/java/org/folio/login/LoginKeycloakApplication.java
@@ -1,13 +1,13 @@
 package org.folio.login;
 
 import org.folio.common.configuration.properties.FolioEnvironment;
-import org.folio.integration.kafka.EnableKafka;
+import org.folio.integration.kafka.producer.EnableKafkaProducer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Import;
 
-@EnableKafka
+@EnableKafkaProducer
 @EnableCaching
 @SpringBootApplication
 @Import(FolioEnvironment.class)

--- a/src/main/java/org/folio/login/integration/kafka/configuration/property/KafkaProperties.java
+++ b/src/main/java/org/folio/login/integration/kafka/configuration/property/KafkaProperties.java
@@ -2,7 +2,7 @@ package org.folio.login.integration.kafka.configuration.property;
 
 import java.util.List;
 import lombok.Data;
-import org.folio.integration.kafka.FolioKafkaProperties.KafkaTopic;
+import org.folio.integration.kafka.producer.KafkaProducerProperties.KafkaTopic;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/folio/login/service/ModuleCustomTenantService.java
+++ b/src/main/java/org/folio/login/service/ModuleCustomTenantService.java
@@ -1,12 +1,12 @@
 package org.folio.login.service;
 
 import static org.folio.common.utils.CollectionUtils.toStream;
-import static org.folio.integration.kafka.KafkaUtils.createTopic;
+import static org.folio.integration.kafka.producer.KafkaUtils.createTopic;
 import static org.folio.login.util.KafkaTopicUtils.getTopicName;
 
 import lombok.extern.log4j.Log4j2;
-import org.folio.integration.kafka.FolioKafkaProperties.KafkaTopic;
-import org.folio.integration.kafka.KafkaAdminService;
+import org.folio.integration.kafka.producer.KafkaAdminService;
+import org.folio.integration.kafka.producer.KafkaProducerProperties.KafkaTopic;
 import org.folio.login.integration.kafka.configuration.property.KafkaProperties;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;

--- a/src/main/java/org/folio/login/util/KafkaTopicUtils.java
+++ b/src/main/java/org/folio/login/util/KafkaTopicUtils.java
@@ -1,7 +1,7 @@
 package org.folio.login.util;
 
 import lombok.experimental.UtilityClass;
-import org.folio.integration.kafka.KafkaUtils;
+import org.folio.integration.kafka.producer.KafkaUtils;
 
 @UtilityClass
 public class KafkaTopicUtils {

--- a/src/test/java/org/folio/login/integration/kafka/configuration/property/KafkaPropertiesTest.java
+++ b/src/test/java/org/folio/login/integration/kafka/configuration/property/KafkaPropertiesTest.java
@@ -3,7 +3,7 @@ package org.folio.login.integration.kafka.configuration.property;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.folio.integration.kafka.FolioKafkaProperties.KafkaTopic;
+import org.folio.integration.kafka.producer.KafkaProducerProperties.KafkaTopic;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/folio/login/it/KafkaPropertiesIT.java
+++ b/src/test/java/org/folio/login/it/KafkaPropertiesIT.java
@@ -2,7 +2,7 @@ package org.folio.login.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.folio.integration.kafka.FolioKafkaProperties.KafkaTopic;
+import org.folio.integration.kafka.producer.KafkaProducerProperties.KafkaTopic;
 import org.folio.login.integration.kafka.configuration.property.KafkaProperties;
 import org.folio.login.support.base.BaseIntegrationTest;
 import org.folio.test.types.IntegrationTest;

--- a/src/test/java/org/folio/login/service/ModuleCustomTenantServiceTest.java
+++ b/src/test/java/org/folio/login/service/ModuleCustomTenantServiceTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.folio.integration.kafka.FolioKafkaProperties.KafkaTopic;
-import org.folio.integration.kafka.KafkaAdminService;
+import org.folio.integration.kafka.producer.KafkaAdminService;
+import org.folio.integration.kafka.producer.KafkaProducerProperties.KafkaTopic;
 import org.folio.login.integration.kafka.configuration.property.KafkaProperties;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;

--- a/src/test/java/org/folio/login/support/TestKafkaUtils.java
+++ b/src/test/java/org/folio/login/support/TestKafkaUtils.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.folio.common.utils.CollectionUtils.mapItems;
-import static org.folio.integration.kafka.KafkaUtils.getTenantTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getTenantTopicName;
 import static org.folio.login.integration.kafka.event.LogoutEvent.Type.LOGOUT;
 import static org.folio.login.support.TestConstants.TENANT;
 import static org.folio.login.support.TestUtils.extractJwtSessionId;


### PR DESCRIPTION
### **Purpose**
Align `mod-login-keycloak` with the applications-poc-tools Kafka module split introduced by APPPOCTOOL-85 so logout event publishing and tenant topic creation continue to work with the new producer library structure. Related issue: https://folio-org.atlassian.net/browse/APPPOCTOOL-85.

### **Approach**
- bump `applications-poc-tools.version` to `4.1.0-SNAPSHOT`
- replace `folio-integration-kafka` with `folio-kafka-producer`
- switch the application bootstrap annotation from `@EnableKafka` to `@EnableKafkaProducer`
- update Kafka producer imports and `KafkaTopic` types in production and test code to the new `org.folio.integration.kafka.producer` package
- keep the existing custom `application.kafka.tenant-topics` configuration and add the required `NEWS.md` entry

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
