### PR TITLE
MODLOGINKC-71: Preserve 401 Unauthorized for invalid login attempts after upgrading from Keycloak 26.5.7 to 26.6.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.1.0` (IN PROGRESS)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
+* Preserve 401 Unauthorized for invalid login attempts after upgrading from Keycloak 26.5.7 to 26.6.2 (MODLOGINKC-71)
 
 ## Version `v4.0.0` (16.04.2026)
 * Adopt APPPOCTOOL-85 Kafka producer module split by moving from `folio-integration-kafka` to `folio-kafka-producer` (APPPOCTOOL-85)

--- a/src/main/java/org/folio/login/service/KeycloakService.java
+++ b/src/main/java/org/folio/login/service/KeycloakService.java
@@ -30,11 +30,13 @@ import org.folio.login.integration.keycloak.KeycloakClient;
 import org.folio.login.util.TokenRequestHelper;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 @Service
@@ -42,17 +44,20 @@ import org.springframework.web.client.RestClientException;
 public class KeycloakService {
 
   private static final String GRANT_TYPE_PASSWORD = "password";
+  private static final String INVALID_GRANT = "invalid_grant";
+
   private final AdminTokenService adminTokenService;
   private final KeycloakUserService keycloakUserService;
   private final KeycloakClient keycloakClient;
   private final FolioExecutionContext folioExecutionContext;
   private final RealmConfigurationProvider realmConfigurationProvider;
   private final LogoutEventPublisher logoutEventPublisher;
+  private final ObjectMapper objectMapper;
 
   public KeycloakAuthentication getUserToken(LoginCredentials credentials, String userAgent, String forwardedFor) {
     var realmConfiguration = realmConfigurationProvider.getRealmConfiguration();
     var requestData = TokenRequestHelper.preparePasswordRequestBody(credentials, realmConfiguration);
-    return getToken(userAgent, forwardedFor, requestData);
+    return getToken(userAgent, forwardedFor, requestData, TokenRequestType.PASSWORD);
   }
 
   public void logout(String refreshToken) {
@@ -94,7 +99,7 @@ public class KeycloakService {
     try (var ctx = new FolioExecutionContextSetter(folioExecutionContext.getFolioModuleMetadata(), headers)) {
       var realmConfiguration = realmConfigurationProvider.getRealmConfiguration();
       var requestData = prepareRefreshRequestBody(refreshToken, realmConfiguration);
-      return getToken(null, null, requestData);
+      return getToken(null, null, requestData, TokenRequestType.REFRESH_TOKEN);
     }
   }
 
@@ -102,7 +107,7 @@ public class KeycloakService {
     String forwardedFor) {
     var realmConfiguration = realmConfigurationProvider.getRealmConfiguration();
     var requestData = prepareCodeRequestBody(code, redirectUri, realmConfiguration);
-    return getToken(userAgent, forwardedFor, requestData);
+    return getToken(userAgent, forwardedFor, requestData, TokenRequestType.AUTHORIZATION_CODE);
   }
 
   @SuppressWarnings("unused")
@@ -182,14 +187,37 @@ public class KeycloakService {
   }
 
   private KeycloakAuthentication getToken(String userAgent, String forwardedFor,
-    MultiValueMap<String, String> payload) {
+    MultiValueMap<String, String> payload, TokenRequestType requestType) {
     var tenantId = folioExecutionContext.getTenantId();
     try {
       return keycloakClient.callTokenEndpoint(tenantId, payload, userAgent, forwardedFor);
     } catch (HttpClientErrorException.Unauthorized e) {
       throw new UnauthorizedException("Unauthorized error", e);
     } catch (RestClientException cause) {
+      if (requestType == TokenRequestType.PASSWORD && isInvalidGrant(cause)) {
+        throw new UnauthorizedException("Unauthorized error", cause);
+      }
       throw new ServiceException("Failed to obtain a token", cause);
     }
+  }
+
+  private boolean isInvalidGrant(Throwable cause) {
+    if (!(cause instanceof HttpClientErrorException.BadRequest badRequest)) {
+      return false;
+    }
+
+    try {
+      var payload = objectMapper.readValue(badRequest.getResponseBodyAsString(), OAuth2ErrorRepresentation.class);
+      return INVALID_GRANT.equals(payload.getError());
+    } catch (Exception e) {
+      log.warn("Failed to parse token error response body", e);
+      return false;
+    }
+  }
+
+  private enum TokenRequestType {
+    PASSWORD,
+    AUTHORIZATION_CODE,
+    REFRESH_TOKEN
   }
 }

--- a/src/test/java/org/folio/login/it/LoginIT.java
+++ b/src/test/java/org/folio/login/it/LoginIT.java
@@ -16,6 +16,7 @@ import static org.folio.login.support.TestConstants.USER_ID;
 import static org.folio.login.support.TestKafkaUtils.assertLogoutEvents;
 import static org.folio.login.support.TestKafkaUtils.logoutAllEvent;
 import static org.folio.login.support.TestKafkaUtils.logoutTopic;
+import static org.folio.login.support.TestValues.invalidLoginCredentials;
 import static org.folio.login.support.TestValues.loginCredentials;
 import static org.folio.login.support.TestValues.requestCookie;
 import static org.folio.login.support.TestValues.requestCookie1;
@@ -102,6 +103,38 @@ class LoginIT extends BaseIntegrationTest {
       .andExpect(header().doesNotExist(XOkapiHeaders.TOKEN))
       .andExpect(cookie().httpOnly(FOLIO_ACCESS_TOKEN, true))
       .andExpect(cookie().httpOnly(FOLIO_REFRESH_TOKEN, true));
+  }
+
+  @Test
+  @KeycloakRealms(realms = "/json/keycloak/test-realm.json")
+  void login_negative_invalidCredentials() throws Exception {
+    mockMvc.perform(post("/authn/login")
+        .content(asJsonString(invalidLoginCredentials()))
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .header(XOkapiHeaders.USER_ID, USER_ID)
+        .header(XOkapiHeaders.URL, OKAPI_URL)
+        .header(XOkapiHeaders.TENANT, TENANT))
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message", is("Unauthorized error")))
+      .andExpect(jsonPath("$.errors[0].type", is("UnauthorizedException")))
+      .andExpect(jsonPath("$.errors[0].code", is("unauthorized_error")));
+  }
+
+  @Test
+  @KeycloakRealms(realms = "/json/keycloak/test-realm.json")
+  void loginWithExpiry_negative_invalidCredentials() throws Exception {
+    mockMvc.perform(post("/authn/login-with-expiry")
+        .content(asJsonString(invalidLoginCredentials()))
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .header(XOkapiHeaders.USER_ID, USER_ID)
+        .header(XOkapiHeaders.URL, OKAPI_URL)
+        .header(XOkapiHeaders.TENANT, TENANT))
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message", is("Unauthorized error")))
+      .andExpect(jsonPath("$.errors[0].type", is("UnauthorizedException")))
+      .andExpect(jsonPath("$.errors[0].code", is("unauthorized_error")));
   }
 
   @Test

--- a/src/test/java/org/folio/login/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/login/service/KeycloakServiceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import org.folio.login.domain.dto.CredentialsExistence;
@@ -58,11 +59,15 @@ import org.keycloak.OAuth2Constants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
+import tools.jackson.databind.ObjectMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +80,7 @@ class KeycloakServiceTest {
   @Mock private FolioExecutionContext folioExecutionContext;
   @Mock private RealmConfigurationProvider realmConfigurationProvider;
   @Mock private LogoutEventPublisher logoutEventPublisher;
+  @Spy private ObjectMapper objectMapper = new ObjectMapper();
   @InjectMocks private KeycloakService keycloakService;
 
   @Test
@@ -124,6 +130,23 @@ class KeycloakServiceTest {
   }
 
   @Test
+  void getTokenByAuthCodeFlow_negative_invalidGrantBadRequest() {
+    var requestData = loginRequestAuthCode(AUTH_CODE, CLIENT_ID, CLIENT_SECRET, "localhost");
+    var realmConfiguration = keycloakRealmConfiguration();
+    var invalidGrantResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"Code not valid\"}";
+
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
+    when(realmConfigurationProvider.getRealmConfiguration()).thenReturn(realmConfiguration);
+    when(keycloakClient.callTokenEndpoint(TENANT, requestData, null, null))
+      .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY,
+        invalidGrantResponse.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> keycloakService.getTokenAuthCodeFlow(AUTH_CODE, "localhost", null, null))
+      .isInstanceOf(ServiceException.class)
+      .hasMessage("Failed to obtain a token");
+  }
+
+  @Test
   void getUserToken_negative_KeycloakError() {
     var requestData = loginRequest(USERNAME, PASSWORD, CLIENT_ID, CLIENT_SECRET);
     var realmConfig = keycloakRealmConfiguration();
@@ -153,6 +176,42 @@ class KeycloakServiceTest {
     assertThatThrownBy(() -> keycloakService.getUserToken(credentials, null, null))
       .isInstanceOf(UnauthorizedException.class)
       .hasMessage("Unauthorized error");
+  }
+
+  @Test
+  void getUserToken_negative_invalidGrantBadRequest() {
+    var requestData = loginRequest(USERNAME, PASSWORD, CLIENT_ID, CLIENT_SECRET);
+    var realmConfig = keycloakRealmConfiguration();
+    var invalidGrantResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"Invalid user credentials\"}";
+
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
+    when(realmConfigurationProvider.getRealmConfiguration()).thenReturn(realmConfig);
+    when(keycloakClient.callTokenEndpoint(TENANT, requestData, null, null))
+      .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY,
+        invalidGrantResponse.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+
+    var credentials = loginCredentials();
+    assertThatThrownBy(() -> keycloakService.getUserToken(credentials, null, null))
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("Unauthorized error");
+  }
+
+  @Test
+  void getUserToken_negative_badRequestWithoutInvalidGrant() {
+    var requestData = loginRequest(USERNAME, PASSWORD, CLIENT_ID, CLIENT_SECRET);
+    var realmConfig = keycloakRealmConfiguration();
+    var badRequestResponse = "{\"error\":\"invalid_request\",\"error_description\":\"Missing parameter\"}";
+
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
+    when(realmConfigurationProvider.getRealmConfiguration()).thenReturn(realmConfig);
+    when(keycloakClient.callTokenEndpoint(TENANT, requestData, null, null))
+      .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY,
+        badRequestResponse.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+
+    var credentials = loginCredentials();
+    assertThatThrownBy(() -> keycloakService.getUserToken(credentials, null, null))
+      .isInstanceOf(ServiceException.class)
+      .hasMessage("Failed to obtain a token");
   }
 
   @Test
@@ -380,5 +439,22 @@ class KeycloakServiceTest {
 
     var actualTokenRequestPayload = captor.getValue();
     assertThat(actualTokenRequestPayload).isEqualTo(requestData);
+  }
+
+  @Test
+  void refreshToken_negative_invalidGrantBadRequest() {
+    var refreshToken = generateJwtToken("http://localhost:8081", TENANT);
+    var invalidGrantResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"Invalid refresh token\"}";
+    var realmConfiguration = keycloakRealmConfiguration();
+
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
+    when(realmConfigurationProvider.getRealmConfiguration()).thenReturn(realmConfiguration);
+    when(keycloakClient.callTokenEndpoint(any(), any(), any(), any()))
+      .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY,
+        invalidGrantResponse.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> keycloakService.refreshToken(refreshToken))
+      .isInstanceOf(ServiceException.class)
+      .hasMessage("Failed to obtain a token");
   }
 }


### PR DESCRIPTION
### **Purpose**
Changes for [MODLOGINKC-71)](https://folio-org.atlassian.net/browse/MODLOGINKC-71)

### **Approach**

- Preserved 401 Unauthorized for invalid credentials on /authn/login and /authn/login-with-expiry after the Keycloak 26.6.2 upgrade.
- Added flow-specific handling in KeycloakService to map password-grant 400 invalid_grant responses back to the existing login error contract.
- Left auth-code and refresh-token flows unchanged, and updated tests to cover the compatibility behavior.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
