### PR TITLE
MODLOGINKC-70: Upgrade dependencies for Kafka 4.2 compatibility in mod-login-keycloak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## Version `v4.1.0` (IN PROGRESS)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
 * Preserve 401 Unauthorized for invalid login attempts after upgrading from Keycloak 26.5.7 to 26.6.2 (MODLOGINKC-71)
+* Upgrade dependencies for Kafka 4.2 compatibility in mod-login-keycloak (MODLOGINKC-70)
+---
 
 ## Version `v4.0.0` (16.04.2026)
 * Adopt APPPOCTOOL-85 Kafka producer module split by moving from `folio-integration-kafka` to `folio-kafka-producer` (APPPOCTOOL-85)

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
     <mod-login-keycloak.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-login-keycloak.yaml
     </mod-login-keycloak.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Test dependencies versions -->
     <testcontainer.version>1.21.4</testcontainer.version>
 


### PR DESCRIPTION
### **Purpose**
Fix [MODLOGINKC-70](https://folio-org.atlassian.net/browse/MODLOGINKC-70)

### **Approach**
Added the following to pom - `<kafka.version>4.2.0</kafka.version>`
<img width="1104" height="814" alt="image" src="https://github.com/user-attachments/assets/02a0ac55-eccc-4207-ad1d-87e200039506" />


---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
